### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -365,7 +365,7 @@ func setupSkaffoldWithArgs(t *testing.T, args ...string) func() {
 }
 
 func randomPort() string {
-	return fmt.Sprintf("%d", rand.Intn(65535))
+	return strconv.Itoa(rand.Intn(65535))
 }
 
 func checkBuildAndDeployComplete(state proto.State) bool {


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```